### PR TITLE
Actually suppress ligatures

### DIFF
--- a/src/subset_gf_icons/subset_gf_icons.py
+++ b/src/subset_gf_icons/subset_gf_icons.py
@@ -42,9 +42,6 @@ flags.DEFINE_enum(
 )
 
 
-ZERO_WIDTH_SPACE = chr(0x200B)
-
-
 def _shape(hb_font, text):
     buf = hb.Buffer()
     buf.add_str(text)
@@ -64,10 +61,13 @@ def _run(argv):
 
     icon_names = set(argv[2:])
 
-    # zero-width space breaks any accidental ligature here
-    name_chars = ZERO_WIDTH_SPACE.join(
+    # \n breaks any accidental ligature here. It will bring in 0 but we want notdef anyway so that's fine.
+    name_chars = "\n".join(
         sorted(reduce(lambda a, e: a | set(e), icon_names, set()))
     )
+    print(name_chars)
+
+
     gids = reduce(
         lambda a, e: a | {e.codepoint},
         _shape(font, name_chars).glyph_infos,
@@ -88,7 +88,6 @@ def _run(argv):
         info = infos[0]
         gids.add(info.codepoint)  # the gid is in .codepoint
 
-    print(f"Subsetting down to {len(gids)} glyphs w/o layout closure")
     options = subset.Options()
     options.layout_closure = False
     subsetter = subset.Subsetter(options)

--- a/src/subset_gf_icons/subset_gf_icons.py
+++ b/src/subset_gf_icons/subset_gf_icons.py
@@ -37,7 +37,7 @@ FLAGS = flags.FLAGS
 flags.DEFINE_enum(
     "flavor",
     None,
-    ['woff', 'woff2'],
+    ["woff", "woff2"],
     "Specify flavor of output font file. May be 'woff' or 'woff2'. If unspecified output is uncompressed.",
 )
 
@@ -62,11 +62,7 @@ def _run(argv):
     icon_names = set(argv[2:])
 
     # \n breaks any accidental ligature here. It will bring in 0 but we want notdef anyway so that's fine.
-    name_chars = "\n".join(
-        sorted(reduce(lambda a, e: a | set(e), icon_names, set()))
-    )
-    print(name_chars)
-
+    name_chars = "\n".join(sorted(reduce(lambda a, e: a | set(e), icon_names, set())))
 
     gids = reduce(
         lambda a, e: a | {e.codepoint},
@@ -98,7 +94,7 @@ def _run(argv):
     out_file = in_file.parent / (in_file.stem + "-subset" + in_file.suffix)
 
     if FLAGS.flavor is not None:
-        out_file = out_file.with_suffix('.' + FLAGS.flavor)
+        out_file = out_file.with_suffix("." + FLAGS.flavor)
         subset_font.flavor = FLAGS.flavor
 
     subset_font.save(out_file)


### PR DESCRIPTION
Fixes bug reported @ https://github.com/google/material-design-icons/issues/1201#issuecomment-1736121116. The join on zero width space wasn't suppressing ligatures so you could end up with some activation characters left out.